### PR TITLE
remove unsupported config key

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,7 @@ TOCtitle="En esta pagina"
 search_placeholder = "Buscar documentos..."
 
 [languages.es]
+generate_feeds = true # there will be a feed for Spanish content
 build_search_index = true
 title="Conforma 🇪🇸"
 

--- a/config.toml
+++ b/config.toml
@@ -25,7 +25,6 @@ TOCtitle="En esta pagina"
 search_placeholder = "Buscar documentos..."
 
 [languages.es]
-generate_feed = true # there will be a feed for Spanish content
 build_search_index = true
 title="Conforma 🇪🇸"
 


### PR DESCRIPTION
I haven't checked if Zola got upgraded to 19.2 recently, but I do know there are many keys from older versions of Zola that aren't supported anymore. `generate_feed` I believe is one of them.

I know this because `brew install zola` installs 19.* and OMS docs are on `16.1` and half the docs explode in a similar way.

I was just going to remove it, but I think it might be just renamed `generate_feeds` 🤷‍♂️ https://www.getzola.org/documentation/templates/feeds/

https://zola.discourse.group/t/generate-feed-vs-generate-feeds/2175

@LaurenceHolding can sleep well knowing this was just a trap and broken before he merged any changes!